### PR TITLE
feat: add terraform destroy capability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   output_path:
     description: "A place to emit the terraform output metadata"
     required: false
+  action:
+    description: "If 'destroy', the resource will run terraform destroy."
+    required: false
 
 runs:
   using: 'docker'
@@ -37,3 +40,4 @@ runs:
     - ${{ inputs.override_files }}
     - ${{ inputs.delete_on_failure }}
     - ${{ inputs.output_path }}
+    - ${{ inputs.action }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,7 @@ VAR_FILES=$4
 OVERRIDE_FILES=$5
 DELETE_ON_FAILURE=$6
 OUTPUT_PATH=$7
+ACTION=$8
 
 if [[ -n $7 ]]; then
   OUTPUT_PATH=$7
@@ -58,7 +59,8 @@ cat > "${tmp_dir}/out.input" <<JSON
     "terraform_source": "$TERRAFORM_SOURCE",
     "var_files": $VAR_FILES,
     "override_files": ${parsed_override_files},
-    "delete_on_failure": $DELETE_ON_FAILURE
+    "delete_on_failure": $DELETE_ON_FAILURE,
+    "action": $ACTION
   },
   "source": $SOURCE
 }
@@ -71,7 +73,8 @@ JSON
     "terraform_source": "$TERRAFORM_SOURCE",
     "var_files": $VAR_FILES,
     "override_files": ${parsed_override_files},
-    "delete_on_failure": $DELETE_ON_FAILURE
+    "delete_on_failure": $DELETE_ON_FAILURE,
+    "action": "$ACTION"
   },
   "source": $SOURCE
 }


### PR DESCRIPTION
I'm not sure if leaving some of the optional args blank such as
```
      - if: ${{ matrix.iaas == 'vsphere'}}
        name: Terraform Destroy
        uses: notrepo05/terraform-action@feature/support-multiple-overrides-harbor
        with:
          env_name: ${{ format('pull-{0}', github.event.number) }}
          terraform_source: "terraforming-repo/${{ matrix.iaas }}/terraforming-pas"
          source: '{ "backend_type": "s3", "backend_config": { "key": "${{ matrix.iaas }}/pull-${{ github.event.number }}.tfstate", "bucket": "releng-terraform-environments", "access_key": "${{ secrets.AWS_TERRAFORM_ACCESS_KEY_ID }}", "secret_key": "${{ secrets.AWS_TERRAFORM_SECRET_ACCESS_KEY }}", "region": "us-west-1" } }'
          var_files: '[ "${{ steps.setup-vsphere-terraform.outputs.vars-file }}" ]'
          override_files: '[ ".github/terraform/${{ matrix.iaas }}" ]'
          action: destroy
```
will parse correctly in the entrypoint.sh.